### PR TITLE
Head Scanning Part 1

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)"
     ],
     install_requires=[
-        'numpy', 'scikit-image', 'Cython', 'numba'
+        'numpy', 'scikit-image', 'Cython', 'numba', 'git+https://github.com/safijari/tiny_tf.git', 'urchin'
     ]
 )

--- a/src/setup.py
+++ b/src/setup.py
@@ -22,6 +22,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)"
     ],
     install_requires=[
-        'numpy', 'scikit-image', 'Cython', 'numba', 'git+https://github.com/safijari/tiny_tf.git', 'urchin'
+        'numpy', 'scikit-image', 'Cython', 'numba', 'urchin'
     ]
 )

--- a/src/stretch_pyfunmap/max_height_image.py
+++ b/src/stretch_pyfunmap/max_height_image.py
@@ -375,7 +375,7 @@ class MaxHeightImage:
         self.transform_corrected_to_original = np.linalg.inv(transform_to_corrected)
 
     def save( self, base_filename, save_visualization=True ):
-        print('MaxHeightImage saving to base_filename =', base_filename)
+        print('MaxHeightImage.save INFO: saving to base_filename =', base_filename)
 
         max_pix = None
         if save_visualization:
@@ -406,7 +406,7 @@ class MaxHeightImage:
             cv2.imwrite(camera_depth_image_filename, self.camera_depth_image)
 
         image_filename = base_filename + '_image.npy.gz'
-        with open(image_filename, 'w') as fid:
+        with open(image_filename, 'wb') as fid:
             np.save(fid, self.image, allow_pickle=False, fix_imports=True)
 
         voi_data = self.voi.serialize()
@@ -451,7 +451,7 @@ class MaxHeightImage:
             data = yaml.load(fid)
 
         image_filename = data['image_filename']
-        with gzip.open(image_filename, 'r') as fid:
+        with gzip.open(image_filename, 'rb') as fid:
             image = np.load(fid)
 
         print('MaxHeightImage: Finished loading serialization data.')

--- a/src/stretch_pyfunmap/max_height_image.py
+++ b/src/stretch_pyfunmap/max_height_image.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from collections import deque
 from scipy.spatial.transform import Rotation
 
+import stretch_pyfunmap.navigation_planning as na
 import stretch_pyfunmap.numba_height_image as nh
 from stretch_pyfunmap.numba_create_plane_image import numba_create_plane_image, numba_correct_height_image, transform_original_to_corrected, transform_corrected_to_original
 
@@ -374,8 +375,8 @@ class MaxHeightImage:
         self.transform_original_to_corrected = transform_to_corrected
         self.transform_corrected_to_original = np.linalg.inv(transform_to_corrected)
 
-    def save( self, base_filename, save_visualization=True ):
-        print('MaxHeightImage.save INFO: saving to base_filename =', base_filename)
+    def save(self, base_filename, save_visualization=True):
+        print(f'MaxHeightImage.save INFO: saving to base_filename = {base_filename}')
 
         max_pix = None
         if save_visualization:
@@ -500,6 +501,61 @@ class MaxHeightImage:
         max_height_image.transform_corrected_to_original = transform_corrected_to_original
 
         return max_height_image
+
+
+    def get_points_to_image_mat(self, points_to_voi_mat):
+        # This returns a matrix that transforms a point in the
+        # provided ROS frame to a point in the image. However, it does
+        # not quantize the components of the image point, which is a
+        # nonlinear operation that must be performed as a separate
+        # step.
+        points_to_voi_mat[:3,3] = points_to_voi_mat[:3,3] - self.image_origin
+        voi_to_image_mat = np.identity(4)
+        voi_to_image_mat[0, 0] = 1.0/self.m_per_pix
+        voi_to_image_mat[1, 1] = - 1.0/self.m_per_pix
+        dtype = self.image.dtype
+        if np.issubdtype(dtype, np.integer):
+            voi_to_image_mat[2, 3] = 1.0
+            voi_to_image_mat[2, 2] = 1.0 / self.m_per_height_unit
+        else:
+            rospy.logerr('MaxHeightImage.get_points_to_image_mat: unsupported image type used for max_height_image, dtype = {0}'.format(dtype))
+            assert(False)
+
+        points_to_image_mat = np.matmul(voi_to_image_mat, points_to_voi_mat)
+
+        if self.transform_original_to_corrected is not None:
+            points_to_image_mat = np.matmul(self.transform_original_to_corrected, points_to_image_mat)
+
+        return points_to_image_mat
+
+
+    def get_robot_pose_in_image(self, robot_to_image_mat):
+        r0 = np.array([0.0, 0.0, 0.0, 1.0])
+        r0 = np.matmul(robot_to_image_mat, r0)[:2]
+        r1 = np.array([1.0, 0.0, 0.0, 1.0])
+        r1 = np.matmul(robot_to_image_mat, r1)[:2]
+        robot_forward = r1 - r0
+        robot_ang_rad = np.arctan2(-robot_forward[1], robot_forward[0])
+        robot_xy_pix = r0
+        return robot_xy_pix, robot_ang_rad
+
+
+    def make_robot_footprint_unobserved(self, robot_x_pix, robot_y_pix, robot_ang_rad):
+        # replace robot points with unobserved points
+        na.draw_robot_footprint_rectangle(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.image, value=0)
+        if self.camera_depth_image is not None:
+            na.draw_robot_footprint_rectangle(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.camera_depth_image, value=0)
+        if self.rgb_image is not None:
+            na.draw_robot_footprint_rectangle(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.rgb_image, value=0)
+
+
+    def make_robot_mast_blind_spot_unobserved(self, robot_x_pix, robot_y_pix, robot_ang_rad):
+        # replace mast blind spot wedge points with unobserved points
+        na.draw_robot_mast_blind_spot_wedge(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.image, value=0)
+        if self.camera_depth_image is not None:
+            na.draw_robot_mast_blind_spot_wedge(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.camera_depth_image, value=0)
+        if self.rgb_image is not None:
+            na.draw_robot_mast_blind_spot_wedge(robot_x_pix, robot_y_pix, robot_ang_rad, self.m_per_pix, self.rgb_image, value=0)
 
 
     def to_points(self, colormap=None, substitute_image=None):

--- a/src/stretch_pyfunmap/merge_maps.py
+++ b/src/stretch_pyfunmap/merge_maps.py
@@ -15,7 +15,7 @@ import stretch_pyfunmap.max_height_image as mh
 import stretch_pyfunmap.navigation_planning as na
 from stretch_pyfunmap.numba_compare_images import numba_compare_images_2
 
-import tf_conversions
+# import tf_conversions
 import hello_helpers.hello_misc as hm
 
 

--- a/src/stretch_pyfunmap/merge_maps.py
+++ b/src/stretch_pyfunmap/merge_maps.py
@@ -15,9 +15,6 @@ import stretch_pyfunmap.max_height_image as mh
 import stretch_pyfunmap.navigation_planning as na
 from stretch_pyfunmap.numba_compare_images import numba_compare_images_2
 
-# import tf_conversions
-import hello_helpers.hello_misc as hm
-
 
 def affine_transform_2d_point(affine_matrix, point):
     affine_point = np.ones(3)
@@ -410,7 +407,7 @@ def estimate_scan_1_to_scan_2_transform(scan_1, scan_2, display_on=False, show_u
     a = p['theta_rad']
     map_x, map_y, map_ang_rad = transform_xya_to_xya_3d(scan_2.image_to_map_mat, x1, y1, a)
     map_xy_1 = np.array([map_x, map_y])
-    map_quat = tf_conversions.transformations.quaternion_from_euler(0, 0, map_ang_rad)
+    map_quat = np.array([0, 0, math.sin(map_ang_rad / 2), math.cos(map_ang_rad / 2)]) # [q_x, q_y, q_z, q_w]
     print('map_xy_1 =', map_xy_1)
     print('map_ang_rad =', map_ang_rad)
     print('map_quat =', map_quat)

--- a/src/stretch_pyfunmap/robot.py
+++ b/src/stretch_pyfunmap/robot.py
@@ -1,10 +1,14 @@
 import sys
+import cv2
+import numpy as np
 import stretch_body.robot
+import pyrealsense2 as rs
 
 
 class FunmapRobot:
 
-    def __init__(self, body=None):
+    def __init__(self, body=None, head_cam=None):
+        # setup Stretch's body
         self.body = body
         if self.body is None:
             self.body = stretch_body.robot.Robot()
@@ -15,3 +19,74 @@ class FunmapRobot:
                 sys.exit(1)
         if not self.body.is_calibrated():
             self.body.home()
+
+        # setup Stretch's head camera
+        self.head_cam = head_cam
+        if self.head_cam is None:
+            self.head_cam = rs.pipeline()
+            fps = 15
+            resolution_color = (1280, 720) # (1920, 1080), (1280, 720), (640, 480)
+            resolution_depth = (1280, 720) # options: (1280, 720), (640, 480)
+            config = rs.config()
+            config.enable_stream(rs.stream.color, resolution_color[0], resolution_color[1], rs.format.bgr8, fps)
+            config.enable_stream(rs.stream.depth, resolution_depth[0], resolution_depth[1], rs.format.z16, fps)
+            self.head_cam.start(config)
+
+    def show_head_cam(self, hold=False, apply_clahe=False, depth_colormap=cv2.COLORMAP_OCEAN):
+        try:
+            while True:
+                # Get the latest frames from the camera
+                frames = self.head_cam.wait_for_frames()
+                color_frame = frames.get_color_frame()
+                depth_frame = frames.get_depth_frame()
+                if not color_frame or not depth_frame:
+                    continue
+
+                # Convert images to numpy arrays
+                color_image = np.asanyarray(color_frame.get_data())
+                depth_image = np.asanyarray(depth_frame.get_data())
+
+                # Apply histogram equalization if desired
+                if apply_local_histogram_equalization:
+                    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8,8))
+                    color_image_lab = cv2.cvtColor(color_image, cv2.COLOR_BGR2LAB)  # convert from BGR to LAB color space
+                    color_image_l, color_image_a, color_image_b = cv2.split(color_image_lab)  # split on 3 different channels
+                    color_image_l_equalized = clahe.apply(color_image_l)  # apply CLAHE to the L-channel
+                    color_image_lab = cv2.merge((color_image_l_equalized, color_image_a, color_image_b))  # merge channels
+                    color_image = cv2.cvtColor(color_image_lab, cv2.COLOR_LAB2BGR)  # convert from LAB to BGR
+
+                # Apply colormap on depth image (image must be converted to 8-bit per pixel first)
+                depth_image = cv2.applyColorMap(cv2.convertScaleAbs(depth_image, alpha=-0.04, beta=255.0), depth_colormap)
+
+                # Rotate and flip images
+                color_image = np.moveaxis(color_image, 0, 1)
+                color_image = np.fliplr(color_image)
+                depth_image = np.moveaxis(depth_image, 0, 1)
+                depth_image = np.fliplr(depth_image)
+
+                # Concatenate images horizontally
+                # Pad images if they are different heights
+                pad_y = color_image.shape[0] - depth_image.shape[0]
+                if pad_y > 0:
+                    color_image_padded = color_image
+                    depth_image_padded = np.pad(depth_image, ((pad_y, 0), (0, 0), (0, 0)), mode='constant', constant_values=0)
+                else:
+                    pad_y = abs(pad_y)
+                    color_image_padded = np.pad(color_image, ((pad_y, 0), (0, 0), (0, 0)), mode='constant', constant_values=0)
+                    depth_image_padded = depth_image
+                # Tile the images
+                colorAndDepth_image = np.hstack((color_image_padded, depth_image_padded))
+
+                # Show image in window
+                cv2.namedWindow('Head Cam', cv2.WINDOW_AUTOSIZE)
+                cv2.imshow('Head Cam', colorAndDepth_image)
+                wknum = 0 if hold else 1 # 0 -> infinite hold, 1 -> loop after 1ms
+                wkret = cv2.waitKey(wknum)
+                wkret = 0 if wkret < 0 else wkret
+                if wkret:
+                    raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            return
+
+    def head_scan(self):
+        pass

--- a/src/stretch_pyfunmap/robot.py
+++ b/src/stretch_pyfunmap/robot.py
@@ -1,0 +1,17 @@
+import sys
+import stretch_body.robot
+
+
+class FunmapRobot:
+
+    def __init__(self, body=None):
+        self.body = body
+        if self.body is None:
+            self.body = stretch_body.robot.Robot()
+            did_start = self.body.startup()
+            if not did_start:
+                print('CRITICAL: hardware failed to initialize completely')
+                self.body.stop()
+                sys.exit(1)
+        if not self.body.is_calibrated():
+            self.body.home()

--- a/src/stretch_pyfunmap/ros_mapping.py
+++ b/src/stretch_pyfunmap/ros_mapping.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import stretch_pyfunmap.mapping as ma
+import stretch_pyfunmap.ros_max_height_image as rmhi
+
+import rospy
+import ros_numpy
+import tf_conversions
+import hello_helpers.hello_misc as hm
+from actionlib_msgs.msg import GoalStatus
+
+
+class ROSHeadScan(ma.HeadScan):
+
+    def __init__(self, node, max_height_im=None, voi_side_m=8.0, voi_origin_m=None):
+        super().__init__(node, max_height_im, voi_side_m, voi_origin_m)
+        rmhi.ROSMaxHeightImage.from_mhi(self.max_height_im) # convert MaxHeightImage to ROS # TODO: implement from_mhi()
+        self.node = self.robot
+
+    def capture_point_clouds(self, pose, capture_params):
+        head_settle_time = capture_params['head_settle_time']
+        num_point_clouds_per_pan_ang = capture_params['num_point_clouds_per_pan_ang']
+        time_between_point_clouds = capture_params['time_between_point_clouds']
+        fast_scan = capture_params.get('fast_scan', False)
+        if fast_scan:
+            num_point_clouds_per_pan_ang = 1
+
+        self.node.move_to_pose(pose)
+        rospy.sleep(head_settle_time)
+        settle_time = rospy.Time.now()
+
+        # Consider using time stamps to make decisions, instead of
+        # hard coded sleep times, as found in the head calibration
+        # data collection code. The main issue is that the robot
+        # needs time to mechanically settle in addition to sensor
+        # timing considerations.
+        prev_cloud_time = None
+        num_point_clouds = 0
+        while num_point_clouds < num_point_clouds_per_pan_ang:
+            rospy.sleep(time_between_point_clouds)
+            cloud_time = self.node.point_cloud.stamp
+            cloud_frame = self.node.point_cloud.header.frame_id
+            point_cloud = ros_numpy.numpify(self.node.point_cloud)
+            if (cloud_time is not None) and (cloud_time != prev_cloud_time) and (cloud_time >= settle_time):
+                rgb_points = ros_numpy.point_cloud2.split_rgb_field(point_cloud)
+                self.max_height_im.from_rgb_points_with_tf2(rgb_points, cloud_frame, self.node.tf2_buffer)
+                num_point_clouds += 1
+                prev_cloud_time = cloud_time
+                
+

--- a/src/stretch_pyfunmap/ros_mapping.py
+++ b/src/stretch_pyfunmap/ros_mapping.py
@@ -47,4 +47,71 @@ class ROSHeadScan(ma.HeadScan):
                 num_point_clouds += 1
                 prev_cloud_time = cloud_time
                 
+    def execute(self, head_tilt, far_left_pan, far_right_pan, num_pan_steps, capture_params, look_at_self=True):
+        scan_start_time = time.time()
 
+        pose = {'joint_head_pan': far_right_pan, 'joint_head_tilt': head_tilt}
+        self.node.move_to_pose(pose)
+
+        pan_left = np.linspace(far_right_pan, far_left_pan, num_pan_steps)
+
+        for pan_ang in pan_left:
+            pose = {'joint_head_pan': pan_ang}
+            self.capture_point_clouds(pose, capture_params)
+
+        # look at the ground right around the robot to detect any
+        # nearby obstacles
+
+        if look_at_self:
+            # Attempt to pick a head pose that sees around the robot,
+            # but doesn't see the mast, which can introduce noise.
+            head_tilt = -1.2
+            head_pan = 0.1
+            pose = {'joint_head_pan': head_pan, 'joint_head_tilt': head_tilt}
+            self.capture_point_clouds(pose, capture_params)
+
+        scan_end_time = time.time()
+        scan_duration = scan_end_time - scan_start_time
+        rospy.loginfo(f'HeadScan.execute INFO: The head scan took {scan_duration} seconds.')
+
+        #####################################
+        # record robot pose information and potentially useful transformations
+        self.robot_xy_pix, self.robot_ang_rad = self.max_height_im.get_robot_pose_in_image(self.node.tf2_buffer)
+
+        # Should only need three of these transforms, since the other
+        # three should be obtainable via matrix inversion. Variation
+        # in time could result in small differences due to encoder
+        # noise.
+        self.base_link_to_image_mat, timestamp = self.max_height_im.get_points_to_image_mat('base_link', self.node.tf2_buffer)
+        self.base_link_to_map_mat, timestamp = hm.get_p1_to_p2_matrix('base_link', 'map', self.node.tf2_buffer)
+        self.image_to_map_mat, timestamp = self.max_height_im.get_image_to_points_mat('map', self.node.tf2_buffer)
+        self.image_to_base_link_mat, timestamp = self.max_height_im.get_image_to_points_mat('base_link', self.node.tf2_buffer)
+        self.map_to_image_mat, timestamp = self.max_height_im.get_points_to_image_mat('map', self.node.tf2_buffer)
+        self.map_to_base_mat, timestamp = hm.get_p1_to_p2_matrix('map', 'base_link', self.node.tf2_buffer)
+
+        self.make_robot_mast_blind_spot_unobserved()
+        self.make_robot_footprint_unobserved()
+
+    def save(self, base_filename, save_visualization=True):
+        rospy.loginfo(f'HeadScan.save INFO: Saving to base_filename = {base_filename}')
+        # save scan to disk
+        max_height_image_base_filename = base_filename + '_mhi'
+        self.max_height_im.save(max_height_image_base_filename)
+
+        if "tolist" in dir(self.robot_ang_rad):
+            robot_ang_rad = self.robot_ang_rad.tolist()
+        else:
+            robot_ang_rad = self.robot_ang_rad
+        data = {'max_height_image_base_filename' : max_height_image_base_filename,
+                'robot_xy_pix' : self.robot_xy_pix.tolist(),
+                'robot_ang_rad' : robot_ang_rad,
+                'timestamp' : {'secs':self.timestamp.secs, 'nsecs':self.timestamp.nsecs},
+                'base_link_to_image_mat' : self.base_link_to_image_mat.tolist(),
+                'base_link_to_map_mat' : self.base_link_to_map_mat.tolist(),
+                'image_to_map_mat' : self.image_to_map_mat.tolist(),
+                'image_to_base_link_mat' : self.image_to_base_link_mat.tolist(),
+                'map_to_image_mat' : self.map_to_image_mat.tolist(),
+                'map_to_base_mat' : self.map_to_base_mat.tolist()}
+
+        with open(base_filename + '.yaml', 'w') as fid:
+            yaml.dump(data, fid)

--- a/src/stretch_pyfunmap/ros_max_height_image.py
+++ b/src/stretch_pyfunmap/ros_max_height_image.py
@@ -13,19 +13,19 @@ from scipy.spatial.transform import Rotation
 from stretch_pyfunmap.max_height_image import *
 import stretch_pyfunmap.navigation_planning as na
 
-import rospy
-import tf2_ros
-import ros_numpy
-import message_filters
-from std_msgs.msg import Header
-from sensor_msgs import point_cloud2
-from sensor_msgs.msg import PointCloud2, PointField
-from sensor_msgs.msg import Imu
-from sensor_msgs.msg import Image
-from visualization_msgs.msg import Marker
-from visualization_msgs.msg import MarkerArray
-from nav_msgs.msg import OccupancyGrid, MapMetaData
-from geometry_msgs.msg import Transform, Pose, Vector3, Quaternion, Point
+# import rospy
+# import tf2_ros
+# import ros_numpy
+# import message_filters
+# from std_msgs.msg import Header
+# from sensor_msgs import point_cloud2
+# from sensor_msgs.msg import PointCloud2, PointField
+# from sensor_msgs.msg import Imu
+# from sensor_msgs.msg import Image
+# from visualization_msgs.msg import Marker
+# from visualization_msgs.msg import MarkerArray
+# from nav_msgs.msg import OccupancyGrid, MapMetaData
+# from geometry_msgs.msg import Transform, Pose, Vector3, Quaternion, Point
 
 
 class ROSVolumeOfInterest(VolumeOfInterest):
@@ -43,6 +43,11 @@ class ROSVolumeOfInterest(VolumeOfInterest):
         if points_to_voi_mat is not None:
             voi_to_points_mat = np.linalg.inv(points_to_voi_mat)
         return voi_to_points_mat, timestamp
+
+    def get_points_to_voi_matrix_with_tinytf2(self, points_frame_id, tf2_buffer):
+        points_to_frame_id_mat = tf2_buffer.lookup_transform(self.frame_id, points_frame_id).matrix
+        points_to_voi_mat = self.get_points_to_voi_matrix(points_to_frame_id_mat)
+        return points_to_voi_mat
 
     def get_points_to_voi_matrix_with_tf2(self, points_frame_id, tf2_buffer, lookup_time=None, timeout_s=None):
         # If the necessary TF2 transform is successfully looked up,
@@ -127,6 +132,27 @@ class ROSMaxHeightImage(MaxHeightImage):
         return max_height_image
 
 
+    def get_points_to_image_mat_tinytf2(self, ros_frame_id, tf2_buffer):
+        points_to_voi_mat = self.voi.get_points_to_voi_matrix_with_tinytf2(ros_frame_id, tf2_buffer)
+        points_to_voi_mat[:3,3] = points_to_voi_mat[:3,3] - self.image_origin
+        voi_to_image_mat = np.identity(4)
+        voi_to_image_mat[0, 0] = 1.0/self.m_per_pix
+        voi_to_image_mat[1, 1] = - 1.0/self.m_per_pix
+        dtype = self.image.dtype
+        if np.issubdtype(dtype, np.integer):
+            voi_to_image_mat[2, 3] = 1.0
+            voi_to_image_mat[2, 2] = 1.0 / self.m_per_height_unit
+        else:
+            print('ROSMaxHeightImage.get_points_to_image_mat ERROR: unsupported image type used for max_height_image, dtype = {0}'.format(dtype))
+            assert(False)
+
+        points_to_image_mat = np.matmul(voi_to_image_mat, points_to_voi_mat)
+
+        if self.transform_original_to_corrected is not None:
+            points_to_image_mat = np.matmul(self.transform_original_to_corrected, points_to_image_mat)
+
+        return points_to_image_mat
+
     def get_points_to_image_mat(self, ros_frame_id, tf2_buffer, lookup_time=None, timeout_s=None):
         # This returns a matrix that transforms a point in the
         # provided ROS frame to a point in the image. However, it does
@@ -188,7 +214,7 @@ class ROSMaxHeightImage(MaxHeightImage):
 
 
     def get_robot_pose_in_image(self, tf2_buffer):
-        robot_to_image_mat, timestamp = self.get_points_to_image_mat('base_link', tf2_buffer)
+        robot_to_image_mat = self.get_points_to_image_mat_tinytf2('base_link', tf2_buffer)
         r0 = np.array([0.0, 0.0, 0.0, 1.0])
         r0 = np.matmul(robot_to_image_mat, r0)[:2]
         r1 = np.array([1.0, 0.0, 0.0, 1.0])
@@ -196,7 +222,7 @@ class ROSMaxHeightImage(MaxHeightImage):
         robot_forward = r1 - r0
         robot_ang_rad = np.arctan2(-robot_forward[1], robot_forward[0])
         robot_xy_pix = r0
-        return robot_xy_pix, robot_ang_rad, timestamp
+        return robot_xy_pix, robot_ang_rad
 
     def get_point_in_image(self, xyz, xyz_frame_id, tf2_buffer):
         point_to_image_mat, timestamp = self.get_points_to_image_mat(xyz_frame_id, tf2_buffer)
@@ -246,6 +272,10 @@ class ROSMaxHeightImage(MaxHeightImage):
                 self.last_update_time = points_timestamp
         else:
             rospy.logwarn('ROSMaxHeightImage.from_points_with_tf2: failed to update the image likely due to a failure to lookup the transform using TF2. points_frame_id = {0}, points_timestamp = {1}, timeout_s = {2}'.format(points_frame_id, points_timestamp, timeout_s))
+
+    def from_rgb_points_with_tinytf2(self, rgb_points, points_frame_id, tf2_buffer):
+        points_to_voi_mat = self.voi.get_points_to_voi_matrix_with_tinytf2(points_frame_id, tf2_buffer)
+        self.from_rgb_points(points_to_voi_mat, rgb_points)
 
     def from_rgb_points_with_tf2(self, rgb_points, points_frame_id, tf2_buffer, points_timestamp=None, timeout_s=None):
         # points should be a numpy array with shape = (N, 3) where N

--- a/src/stretch_pyfunmap/utils.py
+++ b/src/stretch_pyfunmap/utils.py
@@ -1,0 +1,208 @@
+# NOTE: Much of the code in this file is copied from a Intel Realsense example available
+# here: https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/examples/opencv_pointcloud_viewer.py
+# Their Apache 2.0 license can be found here: https://github.com/IntelRealSense/librealsense/blob/master/LICENSE
+
+import cv2
+import math
+import numpy as np
+import pyrealsense2 as rs
+
+
+class AppState:
+
+    def __init__(self, *args, **kwargs):
+        self.WIN_NAME = 'RealSense'
+        self.pitch, self.yaw = math.radians(-10), math.radians(-15)
+        self.translation = np.array([0, 0, -1], dtype=np.float32)
+        self.distance = 2
+        self.prev_mouse = 0, 0
+        self.mouse_btns = [False, False, False]
+        self.paused = False
+        self.decimate = 1
+        self.scale = False
+        self.color = True
+        self.total_image_shape = None
+
+    def reset(self):
+        self.pitch, self.yaw, self.distance = 0, 0, 2
+        self.translation[:] = 0, 0, -1
+
+    @property
+    def rotation(self):
+        Rx, _ = cv2.Rodrigues((self.pitch, 0, 0))
+        Ry, _ = cv2.Rodrigues((0, self.yaw, 0))
+        return np.dot(Ry, Rx).astype(np.float32)
+
+    @property
+    def pivot(self):
+        return self.translation + np.array((0, 0, self.distance), dtype=np.float32)
+
+state = AppState()
+
+
+def project(out, v):
+    """project 3d vector array to 2d"""
+    h, w = out.shape[:2]
+    view_aspect = float(h)/w
+
+    # ignore divide by zero for invalid depth
+    with np.errstate(divide='ignore', invalid='ignore'):
+        proj = v[:, :-1] / v[:, -1, np.newaxis] * \
+            (w*view_aspect, h) + (w/2.0, h/2.0)
+
+    # near clipping
+    znear = 0.03
+    proj[v[:, 2] < znear] = np.nan
+    return proj
+
+
+def view(v):
+    """apply view transformation on vector array"""
+    return np.dot(v - state.pivot, state.rotation) + state.pivot - state.translation
+
+
+def line3d(out, pt1, pt2, color=(0x80, 0x80, 0x80), thickness=1):
+    """draw a 3d line from pt1 to pt2"""
+    p0 = project(out, pt1.reshape(-1, 3))[0]
+    p1 = project(out, pt2.reshape(-1, 3))[0]
+    if np.isnan(p0).any() or np.isnan(p1).any():
+        return
+    p0 = tuple(p0.astype(int))
+    p1 = tuple(p1.astype(int))
+    rect = (0, 0, out.shape[1], out.shape[0])
+    inside, p0, p1 = cv2.clipLine(rect, p0, p1)
+    if inside:
+        cv2.line(out, p0, p1, color, thickness, cv2.LINE_AA)
+
+
+def grid(out, pos, rotation=np.eye(3), size=1, n=10, color=(0x80, 0x80, 0x80)):
+    """draw a grid on xz plane"""
+    pos = np.array(pos)
+    s = size / float(n)
+    s2 = 0.5 * size
+    for i in range(0, n+1):
+        x = -s2 + i*s
+        line3d(out, view(pos + np.dot((x, 0, -s2), rotation)),
+               view(pos + np.dot((x, 0, s2), rotation)), color)
+    for i in range(0, n+1):
+        z = -s2 + i*s
+        line3d(out, view(pos + np.dot((-s2, 0, z), rotation)),
+               view(pos + np.dot((s2, 0, z), rotation)), color)
+
+
+def axes(out, pos, rotation=np.eye(3), size=0.075, thickness=2):
+    """draw 3d axes"""
+    line3d(out, pos, pos +
+           np.dot((0, 0, size), rotation), (0xff, 0, 0), thickness)
+    line3d(out, pos, pos +
+           np.dot((0, size, 0), rotation), (0, 0xff, 0), thickness)
+    line3d(out, pos, pos +
+           np.dot((size, 0, 0), rotation), (0, 0, 0xff), thickness)
+
+
+def frustum(out, intrinsics, color=(0x40, 0x40, 0x40)):
+    """draw camera's frustum"""
+    orig = view([0, 0, 0])
+    w, h = intrinsics.width, intrinsics.height
+
+    for d in range(1, 6, 2):
+        def get_point(x, y):
+            p = rs.rs2_deproject_pixel_to_point(intrinsics, [x, y], d)
+            line3d(out, orig, view(p), color)
+            return p
+
+        top_left = get_point(0, 0)
+        top_right = get_point(w, 0)
+        bottom_right = get_point(w, h)
+        bottom_left = get_point(0, h)
+
+        line3d(out, view(top_left), view(top_right), color)
+        line3d(out, view(top_right), view(bottom_right), color)
+        line3d(out, view(bottom_right), view(bottom_left), color)
+        line3d(out, view(bottom_left), view(top_left), color)
+
+
+def pointcloud(out, verts, texcoords, color, painter=True):
+    """draw point cloud with optional painter's algorithm"""
+    if painter:
+        # Painter's algo, sort points from back to front
+
+        # get reverse sorted indices by z (in view-space)
+        # https://gist.github.com/stevenvo/e3dad127598842459b68
+        v = view(verts)
+        s = v[:, 2].argsort()[::-1]
+        proj = project(out, v[s])
+    else:
+        proj = project(out, view(verts))
+
+    if state.scale:
+        proj *= 0.5**state.decimate
+
+    h, w = out.shape[:2]
+
+    # proj now contains 2d image coordinates
+    j, i = proj.astype(np.uint32).T
+
+    # create a mask to ignore out-of-bound indices
+    im = (i >= 0) & (i < h)
+    jm = (j >= 0) & (j < w)
+    m = im & jm
+
+    cw, ch = color.shape[:2][::-1]
+    if painter:
+        # sort texcoord with same indices as above
+        # texcoords are [0..1] and relative to top-left pixel corner,
+        # multiply by size and add 0.5 to center
+        v, u = (texcoords[s] * (cw, ch) + 0.5).astype(np.uint32).T
+    else:
+        v, u = (texcoords * (cw, ch) + 0.5).astype(np.uint32).T
+    # clip texcoords to image
+    np.clip(u, 0, ch-1, out=u)
+    np.clip(v, 0, cw-1, out=v)
+
+    # perform uv-mapping
+    out[i[m], j[m]] = color[u[m], v[m]]
+
+
+def mouse_cb(event, x, y, flags, param):
+    if event == cv2.EVENT_LBUTTONDOWN:
+        state.mouse_btns[0] = True
+
+    if event == cv2.EVENT_LBUTTONUP:
+        state.mouse_btns[0] = False
+
+    # if event == cv2.EVENT_RBUTTONDOWN:
+    #     state.mouse_btns[1] = True
+
+    # if event == cv2.EVENT_RBUTTONUP:
+    #     state.mouse_btns[1] = False
+
+    # if event == cv2.EVENT_MBUTTONDOWN:
+    #     state.mouse_btns[2] = True
+
+    # if event == cv2.EVENT_MBUTTONUP:
+    #     state.mouse_btns[2] = False
+
+    if event == cv2.EVENT_MOUSEMOVE:
+        h, w = state.total_image_shape[:2]
+        dx, dy = x - state.prev_mouse[0], y - state.prev_mouse[1]
+
+        if state.mouse_btns[0]:
+            state.yaw += float(dy) / w * 2
+            state.pitch += float(dx) / h * 2
+
+        elif state.mouse_btns[1]:
+            dp = np.array((dx / w, dy / h, 0), dtype=np.float32)
+            state.translation -= np.dot(state.rotation, dp)
+
+        elif state.mouse_btns[2]:
+            dz = math.sqrt(dx**2 + dy**2) * math.copysign(0.01, -dy)
+            state.translation[2] += dz
+            state.distance -= dz
+
+    if event == cv2.EVENT_MOUSEWHEEL:
+        dz = math.copysign(0.1, flags)
+        state.translation[2] += dz
+        state.distance -= dz
+
+    state.prev_mouse = (x, y)

--- a/src/stretch_pyfunmap/utils.py
+++ b/src/stretch_pyfunmap/utils.py
@@ -122,23 +122,19 @@ def frustum(out, intrinsics, color=(0x40, 0x40, 0x40)):
         line3d(out, view(bottom_left), view(top_left), color)
 
 
-def pointcloud(out, points_arr):
+def pointcloud(out, cloud):
     """draw point cloud"""
-    verts = np.vstack((points_arr['x'], points_arr['y'], points_arr['z'])).T
+    verts = np.vstack((cloud['x'], cloud['y'], cloud['z'])).T
     proj = project(out, view(verts))
 
-    h, w = out.shape[:2]
-
-    # proj now contains 2d image coordinates
+    # proj now contains 2d image coordinates clipped to the display size
     j, i = proj.astype(np.uint32).T
+    h, w = out.shape[:2]
+    j = np.clip(j, 0, w-1)
+    i = np.clip(i, 0, h-1)
 
-    # create a mask to ignore out-of-bound indices
-    im = (i >= 0) & (i < h)
-    jm = (j >= 0) & (j < w)
-    m = im & jm
-
-    # perform uv-mapping
-    out[i, j] = np.vstack((points_arr['b'], points_arr['g'], points_arr['r'])).T
+    # perform color assignment
+    out[i, j] = np.vstack((cloud['b'], cloud['g'], cloud['r'])).T
 
 
 def mouse_cb(event, x, y, flags, param):
@@ -154,11 +150,11 @@ def mouse_cb(event, x, y, flags, param):
     # if event == cv2.EVENT_RBUTTONUP:
     #     state.mouse_btns[1] = False
 
-    # if event == cv2.EVENT_MBUTTONDOWN:
-    #     state.mouse_btns[2] = True
+    if event == cv2.EVENT_MBUTTONDOWN:
+        state.mouse_btns[2] = True
 
-    # if event == cv2.EVENT_MBUTTONUP:
-    #     state.mouse_btns[2] = False
+    if event == cv2.EVENT_MBUTTONUP:
+        state.mouse_btns[2] = False
 
     if event == cv2.EVENT_MOUSEMOVE:
         h, w = state.total_image_shape[:2]

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,6 +1,6 @@
 import stretch_pyfunmap.robot
 
 robot = stretch_pyfunmap.robot.FunmapRobot()
-if robot.body.is_calibrated():
-    print('Stretch is ready to go')
+robot.show_head_cam(apply_global_histogram_equalization=True)
+# robot.head_scan()
 robot.body.stop()

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,6 +1,7 @@
 import stretch_pyfunmap.robot
 
 robot = stretch_pyfunmap.robot.FunmapRobot()
-robot.show_head_cam(pointcloud=True)
-# robot.head_scan()
+# robot.show_head_cam(pointcloud=True)
+scan = robot.head_scan()
+scan.save('/home/hello-robot/repos/stretch_pyfunmap/src/tools/example_scan')
 robot.body.stop()

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,0 +1,6 @@
+import stretch_pyfunmap.robot
+
+robot = stretch_pyfunmap.robot.FunmapRobot()
+if robot.body.is_calibrated():
+    print('Stretch is ready to go')
+robot.body.stop()

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,6 +1,6 @@
 import stretch_pyfunmap.robot
 
 robot = stretch_pyfunmap.robot.FunmapRobot()
-robot.show_head_cam(apply_global_histogram_equalization=True)
+robot.show_head_cam(align=True)
 # robot.head_scan()
 robot.body.stop()

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,6 +1,6 @@
 import stretch_pyfunmap.robot
 
 robot = stretch_pyfunmap.robot.FunmapRobot()
-robot.show_head_cam(align=True)
+robot.show_head_cam(pointcloud=True)
 # robot.head_scan()
 robot.body.stop()

--- a/src/tools/funmap_head_scan_visualizer.py
+++ b/src/tools/funmap_head_scan_visualizer.py
@@ -1,7 +1,13 @@
+import time
 import stretch_pyfunmap.robot
+import stretch_pyfunmap.mapping as ma
 
 robot = stretch_pyfunmap.robot.FunmapRobot()
-# robot.show_head_cam(pointcloud=True)
-scan = robot.head_scan()
-scan.save('/home/hello-robot/repos/stretch_pyfunmap/src/tools/example_scan')
+robot.body.stow() # Reduce occlusion from the arm and gripper
+
+# Execute head scanning full procedure
+head_scanner = ma.HeadScan(robot, voi_side_m=16.0)
+head_scanner.execute_full()
+head_scanner.save('/home/hello-robot/repos/stretch_pyfunmap/src/tools/example_scan')
+
 robot.body.stop()


### PR DESCRIPTION
This PR lays the groundwork for pure-Python head scanning through FUNMAP. A second PR called "Head Scanning Part 2" will complete the implementation. This PR introduces:

 * `stretch_pyfunmap.robot.FunmapRobot` which provides access to Stretch's body API, Realsense stream, transforms as Numpy matrices, and more.
 * Creates `ros_mapping.py` which extends `HeadScan` from `mapping.py`. All ROS implementation details is moved from the latter to the former.
 * Bug fixes and better separation between `MaxHeightImage` and `ROSMaxHeightImage`.
 * Utils for visualizing data
 * A WIP implementation of head scan visualization in `funmap_head_scan_visualizer.py`

The implementation of head scanning in this PR is buggy. A follow-up PR will complete the implementation.