### PR TITLE
Reduce the entanglements with ROS Pt 1

### DIFF
--- a/src/stretch_pyfunmap/manipulation_planning.py
+++ b/src/stretch_pyfunmap/manipulation_planning.py
@@ -15,7 +15,7 @@ from stretch_pyfunmap.numba_check_line_path import numba_find_contact_along_line
 
 import rospy
 import ros_numpy as rn
-import hello_helpers.hello_misc as hm
+import stretch_pyfunmap.utils as utils
 
 
 def plan_surface_coverage(tool_start_xy_pix, tool_end_xy_pix, tool_extension_direction_xy_pix, step_size_pix, max_extension_pix, surface_mask_image, obstacle_mask_image):
@@ -333,7 +333,7 @@ class ManipulationView():
             # If the directory does not already exist, create it.
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-            filename = 'estimate_reach_to_contact_distance_mask_' + hm.create_time_string() + '.png'
+            filename = 'estimate_reach_to_contact_distance_mask_' + utils.create_time_string() + '.png'
             cv2.imwrite(dirname + filename, mask_image)
 
             line_width = 2
@@ -351,7 +351,7 @@ class ManipulationView():
                 p1 = tuple(np.int32(np.round(contact_xy)))
                 cv2.line(color_im, p0, p1, [255, 0, 0], line_width)
                 cv2.circle(color_im, p1, radius, (0,0,255), 1)
-            filename = 'estimate_reach_to_contact_distance_annotated_mask_' + hm.create_time_string() + '.png'
+            filename = 'estimate_reach_to_contact_distance_annotated_mask_' + utils.create_time_string() + '.png'
             cv2.imwrite(dirname + filename, color_im)
 
             rgb_image = self.max_height_im.rgb_image.copy()
@@ -361,7 +361,7 @@ class ManipulationView():
                 p1 = tuple(np.int32(np.round(contact_xy)))
                 cv2.line(rgb_image, p0, p1, [255, 0, 0], line_width)
                 cv2.circle(rgb_image, p1, radius, (0,0,255), 1)
-            filename = 'estimate_reach_to_contact_distance_annotated_rgb_' + hm.create_time_string() + '.png'
+            filename = 'estimate_reach_to_contact_distance_annotated_rgb_' + utils.create_time_string() + '.png'
             cv2.imwrite(dirname + filename, rgb_image)
 
         else:
@@ -384,7 +384,7 @@ class ManipulationView():
             sm.draw_grasp(rgb_image, grasp_target)
             # Save the new scan to disk.
             dirname = self.debug_directory + 'get_grasp_target/'
-            filename = 'grasp_target_' + hm.create_time_string() + '.png'
+            filename = 'grasp_target_' + utils.create_time_string() + '.png'
             print('ManipulationView get_grasp_target : directory =', dirname)
             print('ManipulationView get_grasp_target : filename =', filename)
             if not os.path.exists(dirname):
@@ -462,7 +462,7 @@ class ManipulationView():
                 side_to_grasp = v1
 
             object_ang_rad = np.arctan2(side_to_grasp[1], -side_to_grasp[0])
-            yaw_angle = float(hm.angle_diff_rad(object_ang_rad, gripper_ang_rad))
+            yaw_angle = float(utils.angle_diff_rad(object_ang_rad, gripper_ang_rad))
 
         return yaw_angle
 
@@ -551,7 +551,7 @@ class ManipulationView():
 
             # Save the new scan to disk.
             dirname = self.debug_directory + 'get_pregrasp_planar_translation/'
-            filename = 'pregrasp_planar_translation_' + hm.create_time_string() + '.png'
+            filename = 'pregrasp_planar_translation_' + utils.create_time_string() + '.png'
             print('ManipulationView get_pregrasp_planar_translation : directory =', dirname)
             print('ManipulationView get_pregrasp_planar_translation : filename =', filename)
             if not os.path.exists(dirname):
@@ -662,7 +662,7 @@ class ManipulationView():
 
             # Save the new scan to disk.
             dirname = self.debug_directory + 'get_grasp_from_pregrasp/'
-            filename = 'grasp_from_pregrasp_' + hm.create_time_string() + '.png'
+            filename = 'grasp_from_pregrasp_' + utils.create_time_string() + '.png'
             print('ManipulationView get_grasp_from_pregrasp : directory =', dirname)
             print('ManipulationView get_grasp_from_pregrasp : filename =', filename)
             if not os.path.exists(dirname):
@@ -816,7 +816,7 @@ class ManipulationView():
 
                     # Save the new scan to disk.
                     dirname = self.debug_directory + 'get_surface_wiping_plan/'
-                    filename = 'surface_wiping_plan_' + hm.create_time_string() + '.png'
+                    filename = 'surface_wiping_plan_' + utils.create_time_string() + '.png'
                     print('ManipulationView get_surface_wiping_plan : directory =', dirname)
                     print('ManipulationView get_surface_wiping_plan : filename =', filename)
                     if not os.path.exists(dirname):

--- a/src/stretch_pyfunmap/mapping.py
+++ b/src/stretch_pyfunmap/mapping.py
@@ -10,7 +10,6 @@ import scipy.ndimage as nd
 import stretch_pyfunmap.merge_maps as mm
 import stretch_pyfunmap.navigation_planning as na
 import stretch_pyfunmap.max_height_image as mhi
-import stretch_pyfunmap.segment_max_height_image as sm
 
 
 def stow_and_lower_arm(node):

--- a/src/stretch_pyfunmap/navigate.py
+++ b/src/stretch_pyfunmap/navigate.py
@@ -8,7 +8,7 @@ import stretch_pyfunmap.ros_max_height_image as rm
 
 import rospy
 import ros_numpy as rn
-import hello_helpers.hello_misc as hm
+import stretch_pyfunmap.utils as utils
 from actionlib_msgs.msg import GoalStatus
 from std_srvs.srv import Trigger, TriggerRequest
 from control_msgs.msg import FollowJointTrajectoryResult
@@ -109,7 +109,7 @@ class FastSingleViewPlanner():
             if debug and (self.debug_directory is not None):
                 # Save the new scan to disk.
                 dirname = self.debug_directory + 'check_line_path/'
-                filename = 'check_line_path_' + hm.create_time_string()
+                filename = 'check_line_path_' + utils.create_time_string()
                 print('FastSingleViewPlanner check_line_path : directory =', dirname)
                 print('FastSingleViewPlanner check_line_path : filename =', filename)
                 if not os.path.exists(dirname):
@@ -140,7 +140,7 @@ class FastSingleViewPlanner():
             if debug and (self.debug_directory is not None):
                 # Save the new scan to disk.
                 dirname = self.debug_directory + 'plan_a_path/'
-                filename = 'plan_a_path_' + hm.create_time_string()
+                filename = 'plan_a_path_' + utils.create_time_string()
                 print('FastSingleViewPlanner plan_a_path : directory =', dirname)
                 print('FastSingleViewPlanner plan_a_path : filename =', filename)
                 if not os.path.exists(dirname):
@@ -335,7 +335,7 @@ class MoveBase():
 
             # Find the angle that the robot should turn in order
             # to achieve the target.
-            turn_angle_error_rad = hm.angle_diff_rad(target_angle_rad, end_angle_rad)
+            turn_angle_error_rad = utils.angle_diff_rad(target_angle_rad, end_angle_rad)
             turn_attempts += 1
 
         if (abs(turn_angle_error_rad) < tolerance_angle_rad):

--- a/src/stretch_pyfunmap/navigation_planning.py
+++ b/src/stretch_pyfunmap/navigation_planning.py
@@ -10,8 +10,6 @@ import stretch_pyfunmap.segment_max_height_image as sm
 from stretch_pyfunmap.numba_check_line_path import numba_check_line_path
 from stretch_pyfunmap.numba_sample_ridge import numba_sample_ridge, numba_sample_ridge_list
 
-import hello_helpers.hello_misc as hm
-
 
 ####################################################
 # DISPLAY FUNCTIONS

--- a/src/stretch_pyfunmap/ros_mapping.py
+++ b/src/stretch_pyfunmap/ros_mapping.py
@@ -6,7 +6,7 @@ import stretch_pyfunmap.ros_max_height_image as rmhi
 import rospy
 import ros_numpy
 import tf_conversions
-import hello_helpers.hello_misc as hm
+import stretch_pyfunmap.utils as utils
 from actionlib_msgs.msg import GoalStatus
 
 
@@ -83,11 +83,11 @@ class ROSHeadScan(ma.HeadScan):
         # in time could result in small differences due to encoder
         # noise.
         self.base_link_to_image_mat, timestamp = self.max_height_im.get_points_to_image_mat('base_link', self.node.tf2_buffer)
-        self.base_link_to_map_mat, timestamp = hm.get_p1_to_p2_matrix('base_link', 'map', self.node.tf2_buffer)
+        self.base_link_to_map_mat, timestamp = utils.get_p1_to_p2_matrix('base_link', 'map', self.node.tf2_buffer)
         self.image_to_map_mat, timestamp = self.max_height_im.get_image_to_points_mat('map', self.node.tf2_buffer)
         self.image_to_base_link_mat, timestamp = self.max_height_im.get_image_to_points_mat('base_link', self.node.tf2_buffer)
         self.map_to_image_mat, timestamp = self.max_height_im.get_points_to_image_mat('map', self.node.tf2_buffer)
-        self.map_to_base_mat, timestamp = hm.get_p1_to_p2_matrix('map', 'base_link', self.node.tf2_buffer)
+        self.map_to_base_mat, timestamp = utils.get_p1_to_p2_matrix('map', 'base_link', self.node.tf2_buffer)
 
         self.make_robot_mast_blind_spot_unobserved()
         self.make_robot_footprint_unobserved()

--- a/src/stretch_pyfunmap/segment_max_height_image.py
+++ b/src/stretch_pyfunmap/segment_max_height_image.py
@@ -9,9 +9,8 @@ import scipy.signal as si
 import scipy.ndimage as nd
 from skimage.morphology import convex_hull_image
 
-import stretch_funmap.max_height_image as mh
-import stretch_funmap.navigation_planning as na
-from stretch_funmap.numba_height_image import numba_create_segment_image_uint8
+import stretch_pyfunmap.navigation_planning as na
+from stretch_pyfunmap.numba_height_image import numba_create_segment_image_uint8
 
 import stretch_pyfunmap.fit_plane as fp
 import stretch_pyfunmap.utils as utils

--- a/src/stretch_pyfunmap/segment_max_height_image.py
+++ b/src/stretch_pyfunmap/segment_max_height_image.py
@@ -13,8 +13,8 @@ import stretch_funmap.max_height_image as mh
 import stretch_funmap.navigation_planning as na
 from stretch_funmap.numba_height_image import numba_create_segment_image_uint8
 
-import hello_helpers.fit_plane as fp
-import hello_helpers.hello_misc as hm
+import stretch_pyfunmap.fit_plane as fp
+import stretch_pyfunmap.utils as utils
 
 
 def find_object_to_grasp(surface_mask, plane_parameters, height_image, display_on=False):
@@ -488,7 +488,7 @@ def find_closest_flat_surface(height_image, robot_xy_pix, display_on=False):
         height, width = surface_label_image.shape
         robot_xy_pix = [width/2, 0]
         robot_loc = np.array(robot_xy_pix)
-        nearest_x, nearest_y, nearest_surface_label = hm.find_nearest_nonzero(surface_label_image, robot_loc)
+        nearest_x, nearest_y, nearest_surface_label = utils.find_nearest_nonzero(surface_label_image, robot_loc)
 
         best_surface = np.uint8(surface_label_image == nearest_surface_label)
 


### PR DESCRIPTION
PyFUNMAP has a pure Python layer where the algorithms reside, and a ROS Python layer which are wrappers. When using the pure Python layer, we want the code in this repo to be self-sufficient (i.e. does not import code or depend on outputs from the ROS code). Since the code was originally copied from Stretch ROS, these layers are still "entangled". This PR removes some of the obvious imports and missing methods, enabling a user to import the `stretch_pyfunmap.robot` module without having ROS installed. The missing hello_misc methods are copied to the `stretch_pyfunmap.utils` module.